### PR TITLE
⚡️(k8s) improve and simplify jibri HPA

### DIFF
--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -7,46 +7,18 @@
 # desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
 # (see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details)
 #
-# If multiple metrics are specified in HPA, the formula is applied for each of them and the
-# higher desiredReplicas is taken into account.
+# If multiple metrics are specified in HPA, the formula is applied for each of
+# them and the higher desiredReplicas is taken into account.
 #
-# In our case, we will specify 2 metrics (or rules) :
-# - one to ensure that we have at least a specific number of pods available (TARGET_MIN_VALUE)
-# - one to ensure that we have a certain percentage of available pods (TARGET_PERCENT)
+# To guarantee that we always have at least TARGET_MIN_VALUE pods available, we
+# just have to set this value as minReplicas because the Deployment manages
+# only available jibris. When a jibri pod is busy, it gets orphaned and is
+# ignored by the Deployment.
 #
-# -- Notes about TARGET_MIN_VALUE
-#
-# This rule is tricky because if we use the raw number of available jibri instances as a metric,
-# HPA would scale in the wrong direction.
-#
-# Example:
-# - TARGET_MIN_VALUE = 2 (we want to have 2 jibri pods available)
-# - 12 jibri pods are running
-# - 10 jibri pods are available
-# - 2 jibri pods are busy.
-#
-# We use the number of available jibri as the metric, in this case:
-# - currentMetricValue = 10
-# - desiredMetricValue = 2
-#
-# If we apply the HPA formula:
-# desiredReplicas = ceil(12 * (10 / 2)) = 60
-#
-# HPA would like to scale up (to 60 pods!) instead of scaling down.
-#
-#
-# To invert this behavior, we can invert the metrics values:
-# - currentMetricValue = 1/10
-# - desiredMetricValue = 1/2
-#
-# If we apply the HPA formula with these metrics instead :
-# desiredReplicas = ceil(12 * ((1/10) / (1/2))) = 3
-#
-# It would scale in the right direction and adjust until it matches the target.
-#
-# All of this to explain that :
-# - We use `jibri_available_inverted` as a metric
-# - The target value is defined as (1 / TARGET_MIN_VALUE)
+# To ensure that we have a certain percentage of available pods
+# (TARGET_PERCENT), a rule is defined in this HPA based on the "jibri_busy"
+# metric, which takes into account all jibri pods in the namespace (those
+# managed by the deployment + the orphaned pods that are busy)
 
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -80,19 +52,6 @@ spec:
     - type: Object
       object:
         metric:
-          name: jibri_available_inverted
-        describedObject:
-          apiVersion: v1
-          kind: Namespace
-          name: jibri
-        target:
-          type: Value
-          # We want to always have 2 available jibri instances.
-          # So we declare 1/2 = 0.5
-          value: 0.5
-    - type: Object
-      object:
-        metric:
           name: jibri_busy
         describedObject:
           apiVersion: v1
@@ -100,5 +59,5 @@ spec:
           name: jibri
         target:
           type: Value
-          # We want to always have 20% of available jibri instances.
+          # We want to always have at least 20% of available jibri instances.
           value: 0.8

--- a/terraform/prometheus-adapter-values.yaml
+++ b/terraform/prometheus-adapter-values.yaml
@@ -23,38 +23,3 @@ rules:
     name:
       as: "jibri_busy"
     metricsQuery: sum(jibri_busystatus{<<.LabelMatchers>>}) by (<<.GroupBy>>) / count(jibri_busystatus{<<.LabelMatchers>>})  by (<<.GroupBy>>)
-  # The jibri_available custom metric indicates if a jibri pod is available to
-  # handle a recording session.
-  # It can be queried manually with :
-  # bin/kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/jibri/pods/*/jibri_available
-  # (value per pod in the jibri namespace)
-  # bin/kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/jibri/metrics/jibri_available
-  # (aggregated value for the whole jibri namespace)
-  - seriesQuery: '{__name__="jibri_busystatus"}'
-    resources:
-      overrides:
-        namespace:
-          resource: namespace
-        pod:
-          resource: pod
-    name:
-      as: "jibri_available"
-    metricsQuery: sum(1 - jibri_busystatus{<<.LabelMatchers>>}) by (<<.GroupBy>>)
-  # The jibri_available_inverted metric is the same than jibri_available, but inverted.
-  # I.e. jibri_available_inverted = 1 / jibri_available
-  # This metric is defined to be used in HPA, in order to scale jibri deployment in the right direction.
-  # If you use jibri_available metric instead, HPA would scale up resources instead of scaling down.
-  #
-  # See HPA algorithm here :
-  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
-  # The formula applied by HPA is : desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
-  - seriesQuery: '{__name__="jibri_busystatus"}'
-    resources:
-      overrides:
-        namespace:
-          resource: namespace
-        pod:
-          resource: pod
-    name:
-      as: "jibri_available_inverted"
-    metricsQuery: 1 / sum(1 - jibri_busystatus{<<.LabelMatchers>>}) by (<<.GroupBy>>)


### PR DESCRIPTION
## Purpose

With jibri HPA, we want to ensure that there is at least :
 - a specific count of jibri pods available (`TARGET_MIN_VALUE`)
 - a specific percentage of jibri pods available across all jibri pods
   (`TARGET_PERCENT`)

A metric rule was specified for each of these requirements.

The first one (`TARGET_MIN_VALUE`) is not necessary anymore, since the jibri Deployment is only managing jibri pods that are not busy. And we can guarantee that this requirement is met with the `minReplicas` instruction.

## Proposal

- [x] remove the HPA rule based on the `jibri_available_inverted` metric
- [x] remove the `jibri_available` and `jibri_available_inverted` metrics from prometheus adapter configuration

This is much easier to understand like this, because the former rule was based on a metric that was quite complex. Also, it is more stable this way, because HPA can instantiate a slightly larger number of pods than necessary, while it adjusts.