### PR TITLE
✨(k8s) use separate nodepool for jibri

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -109,6 +109,8 @@ spec:
         volumeMounts:
         - name: jibri-metadata-updater
           mountPath: /opt/jibri-metadata-updater
+      nodeSelector:
+        k8s.scaleway.com/pool-name: jibri
       restartPolicy: Always
       securityContext: {}
       volumes:

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -9,20 +9,53 @@ resource "scaleway_k8s_cluster" "kube_cluster" {
       maintenance_window_start_hour = lookup(var.k8s_auto_upgrade_maintenance_window_start_hour, terraform.workspace, 3)
       maintenance_window_day = lookup(var.k8s_auto_upgrade_maintenance_window_day, terraform.workspace, "any")
    }
-
 }
 
-resource "scaleway_k8s_pool" "kube_nodepool" {
+# In this cluster, we create 2 nodepools :
+#
+# - The `default` nodepool, on which we'll deploy all pods that do not require
+#   autoscaling feature (e.g. the prometheus stack and basic jitsi components
+#   like prosody and jitsi-meet webserver). It is desirable to isolate them from
+#   nodepools with autoscaling enabled, as they can prevent the Cluster Autoscaler
+#   from removing a node if they run on them.
+#
+# - The `jibri` nodepool, dedicated to jibri instances, with autoscaling enabled.
+#
+# In the future, we'll propably add a nodepool dedicated to videobridges.
+#
+# This separation allows to choose instance types adapted to the needs of each
+# component (e.g. : Jibri consumes a lot of CPU/RAM, Videobridges consume a lot of
+# bandwdith).
+
+
+resource "scaleway_k8s_pool" "default" {
    autohealing         = lookup(var.k8s_nodepool_autohealing, terraform.workspace, true)
-   autoscaling         = lookup(var.k8s_nodepool_autoscale, terraform.workspace, false)
+   autoscaling         = false
    cluster_id          = scaleway_k8s_cluster.kube_cluster.id
    container_runtime   = lookup(var.k8s_nodepool_container_runtime, terraform.workspace, "containerd")
-   max_size            = lookup(var.k8s_nodepool_max_nodes, terraform.workspace, 1)
-   min_size            = lookup(var.k8s_nodepool_min_nodes, terraform.workspace, 1)
-   name                = "jitsi-${terraform.workspace}"
-   node_type           = lookup(var.k8s_nodepool_flavor, terraform.workspace, "GP1-XS")
-   size                = lookup(var.k8s_nodepool_size, terraform.workspace, 1)
+   name                = "default"
+   node_type           = lookup(var.k8s_default_nodepool_flavor, terraform.workspace, "GP1-XS")
+   size                = lookup(var.k8s_default_nodepool_size, terraform.workspace, 1)
    wait_for_pool_ready = true
+}
+
+
+resource "scaleway_k8s_pool" "jibri" {
+   autohealing         = lookup(var.k8s_nodepool_autohealing, terraform.workspace, true)
+   autoscaling         = lookup(var.k8s_jibri_nodepool_autoscale, terraform.workspace, true)
+   cluster_id          = scaleway_k8s_cluster.kube_cluster.id
+   container_runtime   = lookup(var.k8s_nodepool_container_runtime, terraform.workspace, "containerd")
+   max_size            = lookup(var.k8s_jibri_nodepool_max_nodes, terraform.workspace, 5)
+   min_size            = lookup(var.k8s_jibri_nodepool_min_nodes, terraform.workspace, 1)
+   name                = "jibri"
+   node_type           = lookup(var.k8s_jibri_nodepool_flavor, terraform.workspace, "GP1-S")
+   size                = lookup(var.k8s_jibri_nodepool_size, terraform.workspace, 1)
+   wait_for_pool_ready = false
+
+   # We wait for default pool to be ready before creating the jibri pool,
+   # otherwise some kube-system pods created by scaleway might be scheduled
+   # on the jibri pool at cluster initialization
+   depends_on = [ scaleway_k8s_pool.default ]
 }
 
 output "kubeconfig" {

--- a/terraform/prometheus-adapter-values.yaml
+++ b/terraform/prometheus-adapter-values.yaml
@@ -1,3 +1,5 @@
+nodeSelector:
+  k8s.scaleway.com/pool-name: default
 prometheus:
   url: http://prometheus-operated.default.svc
   port: 9090

--- a/terraform/prometheus.tf
+++ b/terraform/prometheus.tf
@@ -8,7 +8,27 @@ resource "helm_release" "kube-prometheus-stack" {
   repository = "https://prometheus-community.github.io/helm-charts"
   chart = "kube-prometheus-stack"
 
-  depends_on = [ scaleway_k8s_pool.kube_nodepool, local_file.kubeconfig]
+  set {
+    name = "alertmanager.alertmanagerSpec.nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  set {
+    name = "prometheusOperator.nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  set {
+    name = "prometheus.prometheusSpec.nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  set {
+    name = "grafana.nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  depends_on = [ scaleway_k8s_pool.default, local_file.kubeconfig]
 }
 
 
@@ -47,6 +67,11 @@ resource "helm_release" "kube-eagle" {
   set {
     name = "serviceMonitor.releaseLabel"
     value = "kube-prometheus-stack"
+  }
+
+  set {
+    name = "nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
   }
 
   depends_on = [ helm_release.kube-prometheus-stack ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -81,15 +81,7 @@ variable "k8s_auto_upgrade_maintenance_window_day" {
   }
 }
 
-# Kubernetes nodepool settings
-
-variable "k8s_nodepool_autoscale" {
-  type = map(bool)
-  description = "Enables the pool autoscaling feature"
-
-  default = {
-  }
-}
+# Global Kubernetes nodepool settings
 
 variable "k8s_nodepool_autohealing" {
   type = map(bool)
@@ -113,35 +105,67 @@ variable "k8s_nodepool_container_runtime" {
   }
 }
 
-variable "k8s_nodepool_flavor" {
+# `default` nodepool settings
+
+variable "k8s_default_nodepool_flavor" {
   type = map(string)
   description = "Flavor name of the instances that will be created for the node pool"
 
+  # You can get the list of available flavors here:
+  # https://www.scaleway.com/en/pricing/
+
   default = {
-    production = "GP1-XS"
+    preprod = "DEV1-M"
   }
 }
 
-variable "k8s_nodepool_min_nodes" {
+variable "k8s_default_nodepool_size" {
   type = map(number)
-  description = "Minimum number of nodes allowed in the node pool"
+  description = "Number of nodes desired in the default pool"
 
   default = {
-    production = 1
   }
 }
 
-variable "k8s_nodepool_max_nodes" {
+
+# `jibri` nodepool settings
+
+
+variable "k8s_jibri_nodepool_autoscale" {
+  type = map(bool)
+  description = "Enables the pool autoscaling feature"
+
+  default = {
+  }
+}
+
+variable "k8s_jibri_nodepool_flavor" {
+  type = map(string)
+  description = "Flavor name of the instances that will be created in the jibri node pool"
+
+  default = {
+    preprod = "DEV1-L"
+  }
+}
+
+variable "k8s_jibri_nodepool_min_nodes" {
   type = map(number)
-  description = "Maximum number of nodes allowed in the pool"
+  description = "Minimum number of nodes allowed in the jibri node pool"
+
+  default = {
+  }
+}
+
+variable "k8s_jibri_nodepool_max_nodes" {
+  type = map(number)
+  description = "Maximum number of nodes allowed in the jibri node pool"
 
   default = {
     preprod = 2
-    production = 5
   }
 }
 
-variable "k8s_nodepool_size" {
+variable "k8s_jibri_nodepool_size" {
   type = map(number)
   description = "Desired pool size. This value will only be used at creation if autoscaling is enabled."
 


### PR DESCRIPTION
## Purpose

At this time, we create a single nodepool on which we schedule all our
pods. Some of them are related to jibri, while others are related to
prometheus or, in a near future, other jitsi components.

Some pods can prevent the cluster autoscaler to remove a jibri node,
for example if they use local storage. (see: [cluster autoscaler FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node) )

To avoid wasting resources while using the cluster autoscaler feature,
we want to isolate jibri pods on a specific nodepool, with autoscaling
enabled. And use another pool for resources that don't need
autoscaling.


