### PR TITLE
✨(terraform) install nginx ingress controller + cert-manager

### DIFF
--- a/terraform/cert-manager.tf
+++ b/terraform/cert-manager.tf
@@ -1,0 +1,38 @@
+
+# Install cert-manager with Helm, to be able to create TLS certificates
+# with Let's encrypt
+
+resource "helm_release" "cert-manager" {
+
+  name = "cert-manager"
+  repository = "https://charts.jetstack.io"
+  chart = "cert-manager"
+
+  set {
+    name = "installCRDs"
+    value = true
+  }
+
+  set {
+    name = "nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  set {
+    name = "webhook.nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  set {
+    name = "cainjector.nodeSelector.k8s\\.scaleway\\.com/pool-name"
+    value = "default"
+  }
+
+  depends_on = [
+    scaleway_k8s_pool.default,
+    local_file.kubeconfig,
+    helm_release.kube-prometheus-stack
+  ]
+
+}
+

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -97,6 +97,13 @@ resource "helm_release" "ingress-nginx" {
    value = "true"
  }
 
+  # The scw-loadbalancer-use-hostname flag allows to execute requests coming from the cluster to the load balancer.
+  # cert-manager self checks dont work without this flag.
+  set {
+    name = "controller.service.annotations.service.beta.kubernetes.io/scw-loadbalancer-use-hostname"
+    value = "true"
+  }
+
   # Assign the reserved IP address to the controller service
   set {
      name = "controller.service.loadBalancerIP"


### PR DESCRIPTION
## Purpose

We want to be able to serve HTTP(S) traffic using Kubernetes ingresses.
Also, we want to be able to generate TLS certificates with Let's Encrypt on the Kubernetes cluster.

## Proposal

- [x] Install nginx-ingress controller with Helm
- [x] Reserve a static Load Balancer IP and attach it to the ingress controller service
- [x] Install cert-manager with Helm

 