### PR TITLE
Rework env to make it easy to add auth by token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix various typing errors
 - `bin/init-overlay` targets the right OVERLAYS_HOME
 
+## Changed
+
+- Rework env to make it easy to add jwt authentication
+
 [Unreleased]: https://github.com/openfun/jitsi-k8s

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ OVERLAYS_HOME=/tmp/my-overlays
 
 ```
 
+## Adding jwt auth
+
+This project is thought to allow delegating authentication to an external gateway like [jitsi magnify](https://github.com/openfun/jitsi-magnify) which uses JWT tokens to authenticate users. To activate this, you can change variables in the `jitsi-common.env` file of your overlay.  For example, to delegate authentication to [jitsi magnify](https://github.com/openfun/jitsi-magnify), change auth type to jwt, put auth_url to url of your external gateway, and set values for app_id and app_secret that will also be set to the same values in magnify.
+
 ## Secrets encryption
 
 If you store your overlays on a shared repository, you might want to encrypt

--- a/k8s/base/env/jitsi-common.env
+++ b/k8s/base/env/jitsi-common.env
@@ -35,15 +35,6 @@ JIBRI_BREWERY_MUC=jibribrewery
 # MUC name for the Jigasi pool.
 JIGASI_BREWERY_MUC=jigasibrewery
 
-# Enable authentication
-ENABLE_AUTH=0
-
-# Enable guest access
-ENABLE_GUESTS=1
-
-# Select authentication type: internal, jwt or ldap
-AUTH_TYPE=internal
-
 # System time zone
 TZ=UTC
 
@@ -58,3 +49,27 @@ ENABLE_XMPP_WEBSOCKET=1
 
 # Enable websocket for colibri (JVB)
 ENABLE_COLIBRI_WEBSOCKET=1
+
+## Authentication
+
+# Enable authentication
+ENABLE_AUTH=0
+
+# Enable guest access
+ENABLE_GUESTS=1
+
+# Select authentication type: internal, jwt or ldap
+AUTH_TYPE=internal
+
+# Application identifier.
+#JWT_APP_ID=my_app_id
+
+# Allow empty JWT tokens ? (guest mode for JWT)
+JWT_ALLOW_EMPTY=0
+
+# JWT authentication type
+JWT_AUTH_TYPE=token
+
+# Authenticate using external service or just focus external auth window if
+# there is one already.
+# TOKEN_AUTH_URL=https://auth.meet.example.com/{room}

--- a/k8s/base/env/jitsi-meet-front.env
+++ b/k8s/base/env/jitsi-meet-front.env
@@ -253,8 +253,3 @@ NGINX_WORKER_PROCESSES=4
 # connections (e.g. connections with proxied servers, among others), not only
 # connections with clients.
 NGINX_WORKER_CONNECTIONS=768
-
-
-# Authenticate using external service or just focus external auth window if
-# there is one already.
-# TOKEN_AUTH_URL=https://auth.meet.example.com/{room}

--- a/k8s/base/env/prosody.env
+++ b/k8s/base/env/prosody.env
@@ -42,7 +42,7 @@ LOG_LEVEL=info
 # JWT authentication
 #
 
-# Application identifier.
+# Application identifier. Managed by jitsi-common.env
 #JWT_APP_ID=my_jitsi_app_id
 
 # Allow empty JWT tokens ? (guest mode for JWT)

--- a/k8s/overlays/.template/jitsi-common.env.tpl
+++ b/k8s/overlays/.template/jitsi-common.env.tpl
@@ -18,3 +18,21 @@ XMPP_MUC_DOMAIN=muc.${BASE_DOMAIN}
 
 # XMPP domain for the jibri recorder
 XMPP_RECORDER_DOMAIN=recorder.${BASE_DOMAIN}
+
+## Authentication
+
+# Enable authentication
+ENABLE_AUTH=0
+
+# Enable guest access
+ENABLE_GUESTS=1
+
+# Select authentication type: internal, jwt or ldap
+AUTH_TYPE=internal
+
+# Application identifier.
+# JWT_APP_ID=my_app_id
+
+# Authenticate using external service or just focus external auth window if
+# there is one already.
+# TOKEN_AUTH_URL=https://auth.meet.example.com/{room}

--- a/k8s/overlays/.template/jitsi-secrets.env.tpl
+++ b/k8s/overlays/.template/jitsi-secrets.env.tpl
@@ -10,3 +10,6 @@ JIBRI_RECORDER_PASSWORD=${JIBRI_RECORDER_PASSWORD}
 
 # XMPP user for Jibri client connections.
 JIBRI_XMPP_PASSWORD=${JIBRI_XMPP_PASSWORD}
+
+# Secret used to sign/verify JWT tokens
+# JWT_APP_SECRET=my_app_secret


### PR DESCRIPTION
## Purpose

Env variables were reworked to make it easy to change auth type to jwt in overlays

Documentation explains how to do it with [magnify](https://github.com/openfun/jitsi-magnify)

## Proposal

- [x] Rework env variable in overlays
- [x] Rework env variables in base
- [x] Explain in README
