### PR TITLE
🔧(kustomize) use images kustomize property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Terraform project to create a K8S cluster on scaleway
 - Kustomize project to deploy jitsi on K8S
+- Example to override images name and tag
 
 ### Fixed
 

--- a/k8s/overlays/.template/kustomization.yaml
+++ b/k8s/overlays/.template/kustomization.yaml
@@ -1,6 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+images:
+  - name: fundocker/jibri-pulseaudio
+    newTag: main
+  - name: jitsi/jicofo
+    newTag: stable-6865
+  - name: jitsi/web
+    newTag: stable-6865
+  - name: jitsi/jvb
+    newTag: stable-6865
+  - name: jitsi/prosody
+    newTag: stable-6865
+
 resources:
   - ../../base
 

--- a/k8s/overlays/example/kustomization.yaml
+++ b/k8s/overlays/example/kustomization.yaml
@@ -11,6 +11,18 @@ configMapGenerator:
     envs:
       - ./jitsi-common.env
 
+images:
+  - name: fundocker/jibri-pulseaudio
+    newTag: main
+  - name: jitsi/jicofo
+    newTag: stable-7001
+  - name: jitsi/web
+    newTag: stable-7001
+  - name: jitsi/jvb
+    newTag: stable-7001
+  - name: jitsi/prosody
+    newTag: stable-7001
+
 generators:
   - ./secret-generator.yaml
 


### PR DESCRIPTION
## Purpose

It is possible to override images tag and name used in the project by
declaring in the kustomize configuration file the images property. The
template and example overlay are modified to show how to use it.

## Proposal

- [x] use images kustomize property