### PR TITLE
configure NGINX_RESOLVER to use coredns 

### DIFF
--- a/k8s/base/env/jitsi-common.env
+++ b/k8s/base/env/jitsi-common.env
@@ -9,7 +9,7 @@ PUBLIC_URL=https://YOUR_DOMAIN
 XMPP_DOMAIN=YOUR_DOMAIN
 
 # Internal XMPP server
-XMPP_SERVER=prosody.jitsi.svc
+XMPP_SERVER=prosody.jitsi.svc.cluster.local
 
 # Internal XMPP domain for authenticated services.
 XMPP_AUTH_DOMAIN=auth.YOUR_DOMAIN

--- a/k8s/base/env/jitsi-meet-front.env
+++ b/k8s/base/env/jitsi-meet-front.env
@@ -9,7 +9,7 @@ DISABLE_HTTPS=1
 ENABLE_HTTP_REDIRECT=0
 
 # Internal XMPP server URL
-XMPP_BOSH_URL_BASE=http://prosody.jitsi.svc:5280
+XMPP_BOSH_URL_BASE=http://prosody.jitsi.svc.cluster.local:5280
 
 # Default language to use
 #DEFAULT_LANGUAGE=
@@ -243,7 +243,7 @@ ENABLE_STATS_ID=false
 # Nginx configuration
 #
 
-NGINX_RESOLVER=127.0.0.1
+NGINX_RESOLVER=coredns.kube-system.svc.cluster.local
 
 # Defines the number of worker processes.
 NGINX_WORKER_PROCESSES=4

--- a/k8s/base/jibri-deployment.yml
+++ b/k8s/base/jibri-deployment.yml
@@ -34,7 +34,7 @@ spec:
     spec:
       serviceAccountName: jibri
       containers:
-      - image: jitsi/jibri:stable-7648-4
+      - image: jitsi/jibri:stable-8044
         name: jibri
         imagePullPolicy: Always
         livenessProbe:

--- a/k8s/base/jicofo-deployment.yml
+++ b/k8s/base/jicofo-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: jitsi-meet
-          image: jitsi/jicofo:stable-7648-4
+          image: jitsi/jicofo:stable-8044
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:

--- a/k8s/base/jitsi-meet-front-deployment.yml
+++ b/k8s/base/jitsi-meet-front-deployment.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: jitsi-meet
-          image: "jitsi/web:stable-7648-4"
+          image: "jitsi/web:stable-8044"
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/k8s/base/jvb-deployment.yml
+++ b/k8s/base/jvb-deployment.yml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 2147483647
       containers:
         - name: jvb
-          image: "jitsi/jvb:stable-7648-4"
+          image: "jitsi/jvb:stable-8044"
           imagePullPolicy: IfNotPresent
            # Hook that waits for users to disconnect before
            # killing the pod

--- a/k8s/base/prosody-deployment.yml
+++ b/k8s/base/prosody-deployment.yml
@@ -16,7 +16,7 @@ spec:
         app: prosody
     spec:
       containers:
-      - image: jitsi/prosody:stable-7648-4
+      - image: jitsi/prosody:stable-8044
         name: prosody
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
## Purpose

Since version stable-7830 of jitsi docker, nginx is not able anymore to
resolve url used internally by services. The service prosody.jitsi.svc
for example is not resolved and nginx is not able to fetch prosody. To
resolve this issue, we choose to ser the variable NGINX_RESOLVER with
the coredns FQDN service url and then use FQDN everywhere in the
configuration when we want to use a service url.


## Proposal

- [x] upgrade jitsi docker images to version stable-8044
- [x]  configure NGINX_RESOLVER to use coredns 
